### PR TITLE
Fix parsing errors

### DIFF
--- a/common/src/main/java/de/crafty/eiv/common/recipe/util/EivTagUtil.java
+++ b/common/src/main/java/de/crafty/eiv/common/recipe/util/EivTagUtil.java
@@ -14,6 +14,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.material.Fluid;
@@ -41,7 +42,7 @@ public class EivTagUtil {
 
 
     public static ItemStack decodeItemStackOnClient(CompoundTag tag) {
-        return ItemStack.CODEC.parse(Minecraft.getInstance().player.level().registryAccess().createSerializationContext(NbtOps.INSTANCE), tag).getOrThrow();
+        return ItemStack.CODEC.parse(Minecraft.getInstance().player.level().registryAccess().createSerializationContext(NbtOps.INSTANCE), tag).result().orElse(ItemStack.EMPTY);
     }
 
     public static CompoundTag encodeItemStackOnClient(ItemStack stack) {
@@ -49,6 +50,9 @@ public class EivTagUtil {
     }
 
     public static CompoundTag encodeItemStackOnServer(ItemStack stack) {
+        if (stack.is(Items.AIR)) {
+            return new CompoundTag();
+        }
         return ItemStack.CODEC.encode(stack, ServerRecipeManager.INSTANCE.getServer().registryAccess().createSerializationContext(NbtOps.INSTANCE), new CompoundTag()).getOrThrow().asCompound().orElseGet(CompoundTag::new);
     }
 

--- a/common/src/main/java/de/crafty/eiv/common/recipe/util/EivTagUtil.java
+++ b/common/src/main/java/de/crafty/eiv/common/recipe/util/EivTagUtil.java
@@ -46,18 +46,18 @@ public class EivTagUtil {
     }
 
     public static CompoundTag encodeItemStackOnClient(ItemStack stack) {
-        return ItemStack.CODEC.encode(stack, Minecraft.getInstance().player.level().registryAccess().createSerializationContext(NbtOps.INSTANCE), new CompoundTag()).getOrThrow().asCompound().orElseGet(CompoundTag::new);
+        return ItemStack.CODEC.encode(stack, Minecraft.getInstance().player.level().registryAccess().createSerializationContext(NbtOps.INSTANCE), new CompoundTag()).result().orElse(new CompoundTag()).asCompound().orElseGet(CompoundTag::new);
     }
 
     public static CompoundTag encodeItemStackOnServer(ItemStack stack) {
         if (stack.is(Items.AIR)) {
             return new CompoundTag();
         }
-        return ItemStack.CODEC.encode(stack, ServerRecipeManager.INSTANCE.getServer().registryAccess().createSerializationContext(NbtOps.INSTANCE), new CompoundTag()).getOrThrow().asCompound().orElseGet(CompoundTag::new);
+        return ItemStack.CODEC.encode(stack, ServerRecipeManager.INSTANCE.getServer().registryAccess().createSerializationContext(NbtOps.INSTANCE), new CompoundTag()).result().orElse(new CompoundTag()).asCompound().orElseGet(CompoundTag::new);
     }
 
     public static ItemStack decodeItemStackOnServer(CompoundTag tag) {
-        return ItemStack.CODEC.parse(ServerRecipeManager.INSTANCE.getServer().registryAccess().createSerializationContext(NbtOps.INSTANCE), tag).getOrThrow();
+        return ItemStack.CODEC.parse(ServerRecipeManager.INSTANCE.getServer().registryAccess().createSerializationContext(NbtOps.INSTANCE), tag).result().orElse(ItemStack.EMPTY);
     }
 
     public static CompoundTag writeIngredient(Ingredient ingredient) {


### PR DESCRIPTION
I was running into the same issue as #18 on 1.21.8, as the mods I have installed have broken recipes. This PR makes the serialization code more able to handle bad data, and allows me to enter my world again.